### PR TITLE
Fix output overwrite in parse.py

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -35,10 +35,7 @@ for lang_file in lang_file_list:
 		continue
 
 	new_lang = updatelang.updatelang(baselang, lang, lang_file)
-
-	f = open(args.output + "/" + lang_file, "a", encoding="utf-8")
-
-	f.truncate(0)
+	f = open(args.output + "/" + lang_file, "w", encoding="utf-8")
 
 	for line in new_lang:
 		f.write(line)


### PR DESCRIPTION
## Summary
- ensure `parse.py` opens output files in write mode

## Testing
- `python3 parse.py -h`
- `python3 -m py_compile parse.py`


------
https://chatgpt.com/codex/tasks/task_e_688932d6e298832c95074b8fac506d54