### PR TITLE
Sync script: comment missing translations

### DIFF
--- a/updatelang.py
+++ b/updatelang.py
@@ -75,10 +75,10 @@ def updatelang(base, update, lang_file):
 				newlang.append(f"{lang_var}.{transline['identifier']} = [[{transline['content']}]]\n")
 
 		else:
-			# not yet translated — copy from base language
+			# not yet translated — keep original text as commented line
 			if line["type"] == "single":
-				newlang.append(f"{lang_var}.{line['identifier']} = \"{line['content']}\"\n")
+				newlang.append(f"-- {lang_var}.{line['identifier']} = \"{line['content']}\"\n")
 			else:
-				newlang.append(f"{lang_var}.{line['identifier']} = [[{line['content']}]]\n")
+				newlang.append(f"-- {lang_var}.{line['identifier']} = [[{line['content']}]]\n")
 
 	return newlang


### PR DESCRIPTION
## Summary
- update `updatelang.py` to comment untranslated lines rather than copying them directly

## Testing
- `python3 parse.py --in languages --out output --base chinese --ignore chinese`

------
https://chatgpt.com/codex/tasks/task_e_6889371b4534832ca91c0ef2be9e77be