### PR TITLE
Sync script: fix unprefixed code lines

### DIFF
--- a/loadfile.py
+++ b/loadfile.py
@@ -88,11 +88,16 @@ def loadfile(path):
         alt_singleline_text_pattern = re.compile(rf'{prefix_any}([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*"((?:\\"|[^"])*)"')
         multiline_text_pattern_open = re.compile(multiline_text_pattern_open_fmt.format(prefix=prefix_dot))
         multiline_single_line = re.compile(multiline_single_line_fmt.format(prefix=prefix_dot))
+        unpref_singleline = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*"((?:\\"|[^"])*)"')
+        unpref_multiline_single = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*\[\[(.*?)\]\]')
+        unpref_multiline_open = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*\[\[(.*)')
 
         # 单行字符串
         singleline_text_match = singleline_text_pattern.search(line)
         if not singleline_text_match:
             singleline_text_match = alt_singleline_text_pattern.search(line)
+        if not singleline_text_match:
+            singleline_text_match = unpref_singleline.search(line)
         if singleline_text_match and line[0:2] != "--":
             data.append({
                 "type": "single",
@@ -105,6 +110,8 @@ def loadfile(path):
 
         # 多行但在一行内
         multisingleline_text_match = re.search(multiline_single_line, line)
+        if not multisingleline_text_match:
+            multisingleline_text_match = re.search(unpref_multiline_single, line)
         if multisingleline_text_match and line[0:2] != "--":
             data.append({
                 "type": "multi",
@@ -117,6 +124,8 @@ def loadfile(path):
 
         # 多行字符串开始
         multiline_text_match_open = re.search(multiline_text_pattern_open, line)
+        if not multiline_text_match_open:
+            multiline_text_match_open = re.search(unpref_multiline_open, line)
         if multiline_text_match_open and line[0:2] != "--":
             data.append({
                 "type": "multi",
@@ -143,11 +152,18 @@ def loadfile(path):
             data[line_counter]["content"] += "\n" + line
             continue
 
-        # 其余认为是空行
-        data.append({
-            "type": "empty",
-            "content": ""
-        })
+        # 其余内容处理
+        if line == "":
+            data.append({
+                "type": "empty",
+                "content": ""
+            })
+        else:
+            # treat unrecognized assignments or other code as literal code lines
+            data.append({
+                "type": "code",
+                "content": line
+            })
         line_counter += 1
 
     return data


### PR DESCRIPTION
## Summary
- add regex support for unprefixed assignments when parsing
- update sync logic to copy code lines from translation files or adapt prefixes
- clean up indentation

## Testing
- `python3 -m py_compile loadfile.py`
- `python3 -m py_compile updatelang.py`
- `python3 parse.py --in languages --out output --base chinese --ignore chinese`

------
https://chatgpt.com/codex/tasks/task_e_6889371b4534832ca91c0ef2be9e77be