### PR TITLE
Sync script: handle nested assignments

### DIFF
--- a/loadfile.py
+++ b/loadfile.py
@@ -88,16 +88,24 @@ def loadfile(path):
         alt_singleline_text_pattern = re.compile(rf'{prefix_any}([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*"((?:\\"|[^"])*)"')
         multiline_text_pattern_open = re.compile(multiline_text_pattern_open_fmt.format(prefix=prefix_dot))
         multiline_single_line = re.compile(multiline_single_line_fmt.format(prefix=prefix_dot))
+        unpref_singleline = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*"((?:\\"|[^"])*)"')
+        unpref_multiline_single = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*\[\[(.*?)\]\]')
+        unpref_multiline_open = re.compile(r'^([a-zA-Z_][a-zA-Z_0-9]*)\s*=\s*\[\[(.*)')
 
         # 单行字符串
         singleline_text_match = singleline_text_pattern.search(line)
+        matched_prefixed = True
         if not singleline_text_match:
             singleline_text_match = alt_singleline_text_pattern.search(line)
+        if not singleline_text_match:
+            singleline_text_match = unpref_singleline.search(line)
+            matched_prefixed = False if singleline_text_match else matched_prefixed
         if singleline_text_match and line[0:2] != "--":
             data.append({
                 "type": "single",
                 "identifier": singleline_text_match.group(1),
-                "content": singleline_text_match.group(2)
+                "content": singleline_text_match.group(2),
+                "prefixed": matched_prefixed
             })
             data[line_counter]["params"] = re.findall(text_param_pattern, data[line_counter]["content"])
             line_counter += 1
@@ -105,11 +113,16 @@ def loadfile(path):
 
         # 多行但在一行内
         multisingleline_text_match = re.search(multiline_single_line, line)
+        matched_prefixed = True
+        if not multisingleline_text_match:
+            multisingleline_text_match = re.search(unpref_multiline_single, line)
+            matched_prefixed = False if multisingleline_text_match else matched_prefixed
         if multisingleline_text_match and line[0:2] != "--":
             data.append({
                 "type": "multi",
                 "identifier": multisingleline_text_match.group(1),
-                "content": multisingleline_text_match.group(2)
+                "content": multisingleline_text_match.group(2),
+                "prefixed": matched_prefixed
             })
             data[line_counter]["params"] = re.findall(text_param_pattern, data[line_counter]["content"])
             line_counter += 1
@@ -117,11 +130,16 @@ def loadfile(path):
 
         # 多行字符串开始
         multiline_text_match_open = re.search(multiline_text_pattern_open, line)
+        matched_prefixed = True
+        if not multiline_text_match_open:
+            multiline_text_match_open = re.search(unpref_multiline_open, line)
+            matched_prefixed = False if multiline_text_match_open else matched_prefixed
         if multiline_text_match_open and line[0:2] != "--":
             data.append({
                 "type": "multi",
                 "identifier": multiline_text_match_open.group(1),
-                "content": multiline_text_match_open.group(2)
+                "content": multiline_text_match_open.group(2),
+                "prefixed": matched_prefixed
             })
             is_multiline = True
             continue
@@ -143,11 +161,18 @@ def loadfile(path):
             data[line_counter]["content"] += "\n" + line
             continue
 
-        # 其余认为是空行
-        data.append({
-            "type": "empty",
-            "content": ""
-        })
+        # 其余内容处理
+        if line == "":
+            data.append({
+                "type": "empty",
+                "content": ""
+            })
+        else:
+            # treat unrecognized assignments or other code as literal code lines
+            data.append({
+                "type": "code",
+                "content": line
+            })
         line_counter += 1
 
     return data

--- a/updatelang.py
+++ b/updatelang.py
@@ -1,84 +1,120 @@
 def getelement(haystack, needle):
-	for line in haystack:
-		try:
-			if line["identifier"] == needle:
-				return line
-		except KeyError:
-			continue
+    for line in haystack:
+        try:
+            if line["identifier"] == needle:
+                return line
+        except KeyError:
+            continue
 
 def getaliasline(array):
-	for i, line in enumerate(array):
-		if line["type"] == "single" and line["identifier"] == "__alias":
-			return i
-	# fallback: first value line
-	for i, line in enumerate(array):
-		if line["type"] in ["single", "multi"]:
-			return i
-	return 0
+    for i, line in enumerate(array):
+        if line["type"] == "single" and line["identifier"] == "__alias":
+            return i
+    # fallback: first value line
+    for i, line in enumerate(array):
+        if line["type"] in ["single", "multi"]:
+            return i
+    return 0
 
 def extract_lang_var(array):
-	for line in array:
-		if line["type"] == "code":
-			try:
-				# e.g., english = {
-				prefix = line["content"].split("=")[0].strip()
-				return prefix
-			except:
-				pass
-	return "L"  # fallback
+    for line in array:
+        if line["type"] == "code":
+            try:
+                # e.g., english = {
+                prefix = line["content"].split("=")[0].strip()
+                return prefix
+            except:
+                pass
+    return "L"  # fallback
+
+def normalize_code_line(line, prefix):
+    """Return line content with leading prefix removed if present."""
+    if line.startswith(prefix):
+        return line[len(prefix):]
+    return line
+
 
 def updatelang(base, update, lang_file):
-	newlang = []
-	lang_var = extract_lang_var(update)  # e.g., english / chinese / traditional
+    newlang = []
+    lang_var = extract_lang_var(update)  # e.g., english / chinese / traditional
+    base_var = extract_lang_var(base)
 
-	# copy header from old file
-	for i in range(0, getaliasline(update)):
-		line = update[i]
+    # copy header from old file
+    for i in range(0, getaliasline(update)):
+        line = update[i]
 
-		if line["type"] == "comment" or line["type"] == "empty":
-			newlang.append("-- " + line["content"] + "\n" if line["content"] != "" else "\n")
-			continue
+        if line["type"] == "comment" or line["type"] == "empty":
+            newlang.append("-- " + line["content"] + "\n" if line["content"] != "" else "\n")
+            continue
 
-		if line["type"] == "code":
-			newlang.append(line["content"] + "\n")
+        if line["type"] == "code":
+            newlang.append(line["content"] + "\n")
 
-	for i in range(getaliasline(base), len(base)):
-		line = base[i]
+    for i in range(getaliasline(base), len(base)):
+        line = base[i]
 
-		if line["type"] == "comment" or line["type"] == "empty":
-			newlang.append("-- " + line["content"] + "\n" if line["content"] != "" else "\n")
-			continue
+        if line["type"] == "comment" or line["type"] == "empty":
+            newlang.append("-- " + line["content"] + "\n" if line["content"] != "" else "\n")
+            continue
+        if line["type"] == "code":
+            # try to find matching code line in update
+            found = None
+            norm_base = normalize_code_line(line["content"], base_var)
+            lhs_base = norm_base.split("=")[0].strip().replace(f".{base_var}", "")
+            for uline in update:
+                if uline["type"] != "code":
+                    continue
+                norm_update = normalize_code_line(uline["content"], lang_var)
+                lhs_update = norm_update.split("=")[0].strip().replace(f".{lang_var}", "")
+                if lhs_update == lhs_base:
+                    found = uline["content"]
+                    break
+            if found:
+                newlang.append(found + "\n")
+            else:
+                # default: copy from base but replace prefix
+                content = line["content"]
+                if content.startswith(base_var):
+                    content = lang_var + content[len(base_var):]
+                else:
+                    content = content.replace(f".{base_var}", f".{lang_var}", 1)
+                newlang.append(content + "\n")
+            continue
 
-		transline = getelement(update, line["identifier"])
+        transline = getelement(update, line["identifier"])
 
-		if transline is not None:
-			in_base_not_in_trans = [p for p in line["params"] if p not in transline["params"]]
-			in_trans_not_in_base = [p for p in transline["params"] if p not in line["params"]]
+        if transline is not None:
+            in_base_not_in_trans = [p for p in line["params"] if p not in transline["params"]]
+            in_trans_not_in_base = [p for p in transline["params"] if p not in line["params"]]
 
-			if in_base_not_in_trans:
-				print(f"[ERROR] in {lang_file}: missing param(s) in translation: {transline['identifier']}")
-				print(" - reference:   " + line["content"].replace("\n", " /// "))
-				print(" - translation: " + transline["content"].replace("\n", " /// "))
-				print(" - missing:     " + str(in_base_not_in_trans))
-				print()
+            if in_base_not_in_trans:
+                print(f"[ERROR] in {lang_file}: missing param(s) in translation: {transline['identifier']}")
+                print(" - reference:   " + line["content"].replace("\n", " /// "))
+                print(" - translation: " + transline["content"].replace("\n", " /// "))
+                print(" - missing:     " + str(in_base_not_in_trans))
+                print()
 
-			if in_trans_not_in_base:
-				print(f"[ERROR] in {lang_file}: unused param(s) in translation: {transline['identifier']}")
-				print(" - reference:   " + line["content"].replace("\n", " /// "))
-				print(" - translation: " + transline["content"].replace("\n", " /// "))
-				print(" - unused:      " + str(in_trans_not_in_base))
-				print()
+            if in_trans_not_in_base:
+                print(f"[ERROR] in {lang_file}: unused param(s) in translation: {transline['identifier']}")
+                print(" - reference:   " + line["content"].replace("\n", " /// "))
+                print(" - translation: " + transline["content"].replace("\n", " /// "))
+                print(" - unused:      " + str(in_trans_not_in_base))
+                print()
 
-			if line["type"] == "single":
-				newlang.append(f"{lang_var}.{transline['identifier']} = \"{transline['content']}\"\n")
-			else:
-				newlang.append(f"{lang_var}.{transline['identifier']} = [[{transline['content']}]]\n")
+            use_prefix = transline.get("prefixed", True)
+            prefix = f"{lang_var}." if use_prefix else ""
+            if line["type"] == "single":
+                newlang.append(f"{prefix}{transline['identifier']} = \"{transline['content']}\"\n")
+            else:
+                newlang.append(f"{prefix}{transline['identifier']} = [[{transline['content']}]]\n")
 
-		else:
-			# not yet translated — copy from base language
-			if line["type"] == "single":
-				newlang.append(f"{lang_var}.{line['identifier']} = \"{line['content']}\"\n")
-			else:
-				newlang.append(f"{lang_var}.{line['identifier']} = [[{line['content']}]]\n")
+        else:
+            # not yet translated — keep original text as commented line
+            use_prefix = line.get("prefixed", True)
+            prefix = f"{lang_var}." if use_prefix else ""
+            if line["type"] == "single":
+                newlang.append(f"-- {prefix}{line['identifier']} = \"{line['content']}\"\n")
+            else:
+                newlang.append(f"-- {prefix}{line['identifier']} = [[{line['content']}]]\n")
 
-	return newlang
+    return newlang


### PR DESCRIPTION
## Summary
- preserve prefix info when parsing language files
- allow updatelang to match nested assignment keys
- keep untranslated lines commented out
- normalize code line prefixes when no translation exists

## Testing
- `python3 -m py_compile loadfile.py updatelang.py parse.py`
- `python3 parse.py --in languages --out output --base chinese --ignore chinese` *(runs successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6889371b4534832ca91c0ef2be9e77be